### PR TITLE
Add type module to package for node to treat codebase as ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "loi-address-service",
   "main": "server.js",
+  "type": "module",
   "dependencies": {
     "axios": "1.15.2",
     "body-parser": "^2.2.0",


### PR DESCRIPTION
(node:7) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///opt/app/server.js is not specified and it doesn't parse as CommonJS. 6
2026-04-29T15:00:14.863Z	Reparsing as ES module because module syntax was detected. This incurs a performance overhead.